### PR TITLE
Add trademarks attribution

### DIFF
--- a/_data/pages/es/home.yml
+++ b/_data/pages/es/home.yml
@@ -121,5 +121,5 @@ partners:
 
 bottomBanner:
   class: '/assets/media/backgrounds/homehero.svg'
-  text: 'Open Distro for Elasticsearch is open source software and licensed under Apache 2.0.'
+  text: 'Open Distro for Elasticsearch is open source software and licensed under Apache 2.0. Elasticsearch and Kibana are trademarks of Elasticsearch BV, registered in the U.S. and in other countries.'
   color: "#0a1f72"


### PR DESCRIPTION
According to https://www.elastic.co/legal/trademarks you must clearly attribute the brand names. This or a similar text should probably be added to the footer of every single page in both the webpage and documentation?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
