### PR TITLE
Fix css

### DIFF
--- a/_sass/bootstrap-4-jekyll/_bootstrap-4-jekyll.scss
+++ b/_sass/bootstrap-4-jekyll/_bootstrap-4-jekyll.scss
@@ -574,7 +574,6 @@
 
   .text { 
     font-size: 1.2rem;
-    letter-spacing: 1px;
     line-height: 1.6;
     color: #111;
     font-weight: 200;
@@ -1405,7 +1404,6 @@ height: 250px;
 
   .text { 
     font-size: 1.2rem;
-    letter-spacing: 1px;
     line-height: 1.6;
     color: #111;
     font-weight: 200;

--- a/_sass/bootstrap-4-jekyll/_bootstrap-4-jekyll.scss
+++ b/_sass/bootstrap-4-jekyll/_bootstrap-4-jekyll.scss
@@ -144,7 +144,6 @@
 
   .text { 
     font-size: 1.2rem;
-    letter-spacing: 1px;
     line-height: 1.6;
     color: #111;
     font-weight: 200;
@@ -482,7 +481,6 @@
   .title {
     font-size: 2.3rem;
     line-height: 1.5;
-    letter-spacing: 1px;
     font-weight: 200;
   }
 
@@ -584,7 +582,6 @@
 
   .text-md { 
     font-size: 1.4rem;
-    letter-spacing: 1px;
     line-height: 1.7;
     color: #111;
     font-weight: 150;
@@ -989,7 +986,6 @@
 
   .text { 
     font-size: 1.2rem;
-    letter-spacing: 1px;
     line-height: 1.6;
     color: #111;
     font-weight: 200;
@@ -1815,7 +1811,6 @@ height: 180px;
 
   .text { 
      font-size: 1.2rem;
-     letter-spacing: 1px;
      line-height: 1.6;
      color: #111;
      font-weight: 200;


### PR DESCRIPTION
Issue #, if available:
Text wrapping per charector

Description of changes:
Text wrapping per charector was caused by letter spacing set to: 1px: letter-spacing: 1px; Removed this to fix the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.