### PR TITLE
Updated links for Data Prepper 0.8.0

### DIFF
--- a/_data/pages/es/downloads.yml
+++ b/_data/pages/es/downloads.yml
@@ -165,14 +165,14 @@ alldownloads:
     - 'downloads/odfe-windows/ode-windows-zip/opendistroforelasticsearch-1.13.1-windows-x64.zip'
     - 'downloads/odfe-windows/odfe-executables/opendistroforelasticsearch-kibana-1.13.1-windows-x64.exe'
     - 'downloads/odfe-windows/ode-windows-zip/opendistroforelasticsearch-kibana-1.13.1-windows-x64.zip'
-    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-jdk-0.7.1-alpha-linux-x64.tar.gz'
-    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-jdk-0.7.1-alpha-linux-x64.zip'
-    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-jdk-0.7.1-alpha-macos-x64.tar.gz'
-    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-jdk-0.7.1-alpha-macos-x64.zip'
-    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-0.7.1-alpha-linux-x64.tar.gz'
-    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-0.7.1-alpha-linux-x64.zip'
-    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-0.7.1-alpha-macos-x64.tar.gz'
-    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-0.7.1-alpha-macos-x64.zip'
+    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-jdk-0.8.0-beta-linux-x64.tar.gz'
+    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-jdk-0.8.0-beta-linux-x64.zip'
+    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-jdk-0.8.0-beta-macos-x64.tar.gz'
+    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-jdk-0.8.0-beta-macos-x64.zip'
+    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-0.8.0-beta-linux-x64.tar.gz'
+    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-0.8.0-beta-linux-x64.zip'
+    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-0.8.0-beta-macos-x64.tar.gz'
+    - 'tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-0.8.0-beta-macos-x64.zip'
     - 'downloads/elasticsearch-clients/opendistro-sql-jdbc/opendistro-sql-jdbc-1.13.0.0.jar'
     - 'downloads/elasticsearch-clients/opendistro-sql-odbc/mac/opendistro-sql-odbc-1.13.0.0-macos-x64.pkg'
     - 'downloads/elasticsearch-clients/opendistro-sql-odbc/windows/opendistro-sql-odbc-1.13.0.0-windows-x86.msi'
@@ -210,7 +210,7 @@ dataprepper:
               artifacts:
                 zip:
                   title: '.zip Archive'
-                  uri: 'https://d3g5vo6xdbdb9a.cloudfront.net/tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-jdk-0.7.1-alpha-linux-x64.zip'
+                  uri: 'https://d3g5vo6xdbdb9a.cloudfront.net/tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-jdk-0.8.0-beta-linux-x64.zip'
         macos:
           parts:
             macos:
@@ -218,7 +218,7 @@ dataprepper:
               artifacts:
                 zip:
                   title: '.zip Archive'
-                  uri: 'https://d3g5vo6xdbdb9a.cloudfront.net/tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-jdk-0.7.1-alpha-macos-x64.zip'
+                  uri: 'https://d3g5vo6xdbdb9a.cloudfront.net/tarball/opendistroforelasticsearch-data-prepper/opendistroforelasticsearch-data-prepper-jdk-0.8.0-beta-macos-x64.zip'
 
 prod:
   id: 'prod'


### PR DESCRIPTION
*Description of changes:*
* Updated links to point to new 0.8.0-beta release of Data Prepper

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
