### PR TITLE
Update odfe-cli to 1.1.1

### DIFF
--- a/_data/pages/es/downloads.yml
+++ b/_data/pages/es/downloads.yml
@@ -177,11 +177,11 @@ alldownloads:
     - 'downloads/elasticsearch-clients/opendistro-sql-odbc/mac/opendistro-sql-odbc-1.13.0.0-macos-x64.pkg'
     - 'downloads/elasticsearch-clients/opendistro-sql-odbc/windows/opendistro-sql-odbc-1.13.0.1-windows-x86.msi'
     - 'downloads/elasticsearch-clients/opendistro-sql-odbc/windows/opendistro-sql-odbc-1.13.0.1-windows-x64.msi'
-    - 'downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.0-linux-arm64.zip'
-    - 'downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.0-linux-x64.zip'
-    - 'downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.0-macos-x64.zip'
-    - 'downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.0-windows-x86.zip'
-    - 'downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.0-windows-x64.zip'
+    - 'downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.1-linux-arm64.zip'
+    - 'downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.1-linux-x64.zip'
+    - 'downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.1-macos-x64.zip'
+    - 'downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.1-windows-x86.zip'
+    - 'downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.1-windows-x64.zip'
 
 
 dataprepper:
@@ -318,7 +318,7 @@ drivers:
 odfecli:
   id: 'odfecli'
   title: 'Command line management / `odfe-cli`'
-  description: 'Parts of Open Distro can be managed from the command line directly using `odfe-cli`. Current Version: 1.1.0'
+  description: 'Parts of Open Distro can be managed from the command line directly using `odfe-cli`. Current Version: 1.1.1'
   arch:
     -
       title: 'x64'
@@ -331,13 +331,13 @@ odfecli:
               artifacts:
                 zip:
                   title: '.zip Archive'
-                  uri: 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.0-windows-x64.zip'
+                  uri: 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.1-windows-x64.zip'
             linux:
               title: 'Linux'
               artifacts:
                 zip:
                   title: '.zip Archive'
-                  uri: 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.0-linux-x64.zip'
+                  uri: 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.1-linux-x64.zip'
         macos:
           parts:
             macOS:
@@ -345,7 +345,7 @@ odfecli:
               artifacts:
                 zip:
                   title: '.zip Archive'
-                  uri: 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.0-macos-x64.zip'
+                  uri: 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.1-macos-x64.zip'
     -
       title: 'x86'
       id: 'x86'
@@ -357,7 +357,7 @@ odfecli:
               artifacts:
                 zip:
                   title: '.zip Archive'
-                  uri: 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.0-windows-x86.zip'
+                  uri: 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.1-windows-x86.zip'
     -
       title: 'arm64'
       id: 'arm64'
@@ -369,7 +369,7 @@ odfecli:
               artifacts:
                 zip:
                   title: '.zip Archive'
-                  uri: 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.0-linux-arm64.zip'
+                  uri: 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-clients/opendistro-cli/opendistro-odfe-cli-1.1.1-linux-arm64.zip'
 
 perftop:
   id: 'perftop'


### PR DESCRIPTION
Update odfe-cli to 1.1.1. This is already released and available for downloads.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
